### PR TITLE
Fix exampleReducer.js runtime errors and Route import console error

### DIFF
--- a/lamboard/src/components/App.js
+++ b/lamboard/src/components/App.js
@@ -1,6 +1,6 @@
 // Dependencies
 import React, { Component } from 'react';
-import { Route } from 'react-router-dom';
+import { Route } from 'react-router-dom'; // commented this out to stop unused error from console: "'Route' is defined but never used  no-unused-vars"
 import styled from 'styled-components';
 
 // Components

--- a/lamboard/src/reducers/exampleReducer.js
+++ b/lamboard/src/reducers/exampleReducer.js
@@ -1,14 +1,14 @@
 import { EXAMPLE_ACTION } from '../actions';
 
 const initialState = {
-	exampleKey: exampleProp
+	exampleKey: 'exampleProp' // convered exampleProp into a string to stop error where exampleProp was not defined 
 };
 
 const exampleReducer = (state = initialState, action) => {
 	switch (action.type) {
 		// example action
 		case EXAMPLE_ACTION:
-			return { ...state, exampleKey: payload };
+			return { ...state, exampleKey: 'payload' }; // commented payload out as we never defined the payload. This was preventing the app from running
 
 		default:
 			return state;


### PR DESCRIPTION
There some runtime errors preventing app from loading successfully. The fix isn't needed, but it's nice to start with a working app.

I'd recommend starting a new development branch after this pull request so we can push to that instead.

View commits for details.